### PR TITLE
Display SQLite error messages for 'Unknown' error code

### DIFF
--- a/src/interop.rs
+++ b/src/interop.rs
@@ -103,8 +103,8 @@ impl IntoTonicStatus for rusqlite::Error {
                         Some(message) => message,
                         None => "no message",
                     };
-                    Status::unknown(format!("unknown :{message}"))
-                },
+                    Status::unknown(format!("unknown: {message}"))
+                }
                 _ => Status::unknown("unknown"),
             },
             Self::SqliteSingleThreadedMode => Status::internal("sqlite single threaded mode"),


### PR DESCRIPTION
As a first-time developer, I spent some time figuring out why some blob test cases for SQLite were failing (#15).

The issues were:
- SQLite 3.34 does not support `RETURNING` clause (which is supported from  3.35.0).
- It took some time investigating because the error message didn't show the error message from SQLite for ErrorCode.Unknown.

This PR slightly enhances error message handling and documents the minimum supported SQLite version.