### PR TITLE
fix issues with blob benchmarks

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -6,7 +6,7 @@
 )]
 
 mod blob;
-mod kv;
+// mod kv;
 
 use criterion::Criterion;
 use std::time::Duration;
@@ -25,4 +25,4 @@ fn create_runtime() -> tokio::runtime::Runtime {
         .unwrap()
 }
 
-criterion::criterion_main!(blob::blob, kv::kv);
+criterion::criterion_main!(blob::blob /*kv::kv*/,);


### PR DESCRIPTION
Hi Marcus,

I'm trying to fix the benchmarking code and for some reason I keep encountering the following issues.

```
Benchmarking sqlite_blob_update_metadata: Warming up for 3.0000 sthread 'main' panicked at benches/blob.rs:212:81:
called `Result::unwrap()` on an `Err` value: Status { code: Unavailable, message: "Client already taken", source: Some(tonic::transport::Error(Transport, ConnectError(Custom { kind: Other, error: "Client already taken" }))) }
```

Any ideas?