### PR TITLE
Implement composite index

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -172,7 +172,7 @@ impl SecondaryIndex {
                     if !existing_keys.is_empty() && !existing_keys.contains(&key.to_string()) {
                         return Err(IndexError::UniqueConstraintViolation {
                             index: self.config.name.clone(),
-                            value: format!("{:?}", composite_key),
+                            value: format!("{composite_key:?}"),
                         });
                     }
                 }
@@ -181,6 +181,7 @@ impl SecondaryIndex {
                 .entry(composite_key)
                 .or_default()
                 .insert(key.to_string());
+            drop(index);
             Ok(())
         } else {
             Err(IndexError::UnsupportedIndexType)
@@ -237,6 +238,7 @@ impl SecondaryIndex {
                 let _ = keys.remove(key);
                 if keys.is_empty() {
                     drop(index.remove(&composite_key));
+                    drop(index);
                 }
             }
             Ok(())


### PR DESCRIPTION
I've implemented the following features for composite indexes:
* **create**
* **find_exact**
* **remove**

I've also added respective tests.

One question I have regarding the composite index is whether it should support a **`find_partial`** feature. For example, given the following structure:

```
{
  (thing1, thing2): [doc1, doc2],
  (thing1, thing3): [doc3, doc4]
}
```

should `find((thing1, _))` return `[doc1, doc2, doc3, doc4]`?

