### PR TITLE
lay out proper error management system for `DatabaseBackend` trait

### DIFF
--- a/src/backend/arc.rs
+++ b/src/backend/arc.rs
@@ -1,3 +1,4 @@
+use crate::backend::error::BackendError;
 use crate::backend::{BlobBackend, DatabaseBackend, KvBackend};
 use crate::proto::{blob, kv};
 use crate::{Location, StreamingRequest};
@@ -9,9 +10,9 @@ where
     Backend: DatabaseBackend,
 {
     type Connection = Backend::Connection;
-    type Error = Backend::Error;
+    // type Error = Backend::Error;
 
-    fn at_location(location: Location) -> Result<Self, Self::Error> {
+    fn at_location(location: Location) -> Result<Self, BackendError> {
         Backend::at_location(location).map(Self::new)
     }
 
@@ -19,7 +20,7 @@ where
         self.as_ref().location()
     }
 
-    fn connect(&self) -> Result<Self::Connection, Self::Error> {
+    fn connect(&self) -> Result<Self::Connection, BackendError> {
         self.as_ref().connect()
     }
 }
@@ -33,7 +34,7 @@ where
     type SetStream = Backend::SetStream;
     type DeleteStream = Backend::DeleteStream;
 
-    fn initialize(&self, connection: &Self::Connection) -> Result<(), Self::Error> {
+    fn initialize(&self, connection: &Self::Connection) -> Result<(), BackendError> {
         self.as_ref().initialize(connection)
     }
 
@@ -80,7 +81,7 @@ where
     type UpdateStream = Backend::UpdateStream;
     type DeleteStream = Backend::DeleteStream;
 
-    fn initialize(&self, connection: &Self::Connection) -> Result<(), Self::Error> {
+    fn initialize(&self, connection: &Self::Connection) -> Result<(), BackendError> {
         self.as_ref().initialize(connection)
     }
 

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -35,7 +35,7 @@ impl IntoTonicStatus for BackendError {
                     rusqlite::ErrorCode::ConstraintViolation => tonic::Status::already_exists(
                         msg.unwrap_or_else(|| "Constraint violation".into()),
                     ),
-                    _ => tonic::Status::internal(format!("Database error: {} {:?}", e, msg)),
+                    _ => tonic::Status::internal(format!("Database error: {e} {msg:?}")),
                 },
                 _ => {
                     tonic::Status::internal(format!("Unhandled database error: {}", db_err.source))

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -1,11 +1,65 @@
+use crate::interop::IntoTonicStatus;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[error("Sqlite operation failed: {source}")]
+pub struct SqliteError {
+    #[from]
+    pub source: rusqlite::Error,
+}
+
+impl From<rusqlite::Error> for BackendError {
+    fn from(value: rusqlite::Error) -> Self {
+        Self::RusQliteError(SqliteError { source: value })
+    }
+}
+
+impl BackendError {
+    pub fn sqlite(err: rusqlite::Error) -> Self {
+        Self::RusQliteError(SqliteError { source: err })
+    }
+}
+
+impl IntoTonicStatus for BackendError {
+    fn into_tonic_status(self) -> tonic::Status {
+        match self {
+            Self::Connection { message } => tonic::Status::failed_precondition(format!(
+                "Unable to establish connection: {message}"
+            )),
+            Self::InvalidLocation { message } => tonic::Status::invalid_argument(message),
+            Self::RusQliteError(db_err) => match db_err.source {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    tonic::Status::not_found("record not found in database")
+                }
+                rusqlite::Error::SqliteFailure(e, msg) => match e.code {
+                    rusqlite::ErrorCode::ConstraintViolation => tonic::Status::already_exists(
+                        msg.unwrap_or_else(|| "Constraint violation".into()),
+                    ),
+                    _ => tonic::Status::internal(format!("Database error: {} {:?}", e, msg)),
+                },
+                _ => {
+                    tonic::Status::internal(format!("Unhandled database error: {}", db_err.source))
+                }
+            },
+            Self::Initialization { message } => tonic::Status::internal(message),
+            Self::Generic { message } => tonic::Status::internal(message),
+            Self::Unknown => tonic::Status::internal("An unknown error occured"),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum BackendError {
-    #[error("unable to have both locations for blob and kv as in memory")]
-    BothLocationInMemory,
-    #[error("generic backend error: `{0}`")]
-    Generic(String),
+    #[error("connection error: `{message}`")]
+    Connection { message: String },
+    #[error("rusqlite error: `{0}`")]
+    RusQliteError(#[from] SqliteError),
+    #[error("invalid location: `{message}`")]
+    InvalidLocation { message: String },
+    #[error("initialization error: `{message}`")]
+    Initialization { message: String },
+    #[error("generic backend error: `{message}`")]
+    Generic { message: String },
     #[error("unknown backend error")]
     Unknown,
 }

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BackendError {
+    #[error("unable to have both locations for blob and kv as in memory")]
+    BothLocationInMemory,
+    #[error("generic backend error: `{0}`")]
+    Generic(String),
+    #[error("unknown backend error")]
+    Unknown,
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -27,6 +27,8 @@ mod sealed {
     impl<T> Sealed for Arc<T> {}
 }
 
+mod error;
+
 // #[cfg(feature = "duckdb")]
 // pub use self::duckdb::DuckDb;
 #[cfg(feature = "sqlite")]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -44,9 +44,8 @@ use tonic::async_trait;
 pub trait DatabaseBackend: sealed::Sealed + Sized {
     /// The type of connection to the database.
     type Connection;
-    /// The type of any errors returned by the backend.
+    // /// The type of any errors returned by the backend.
     // type Error; // TODO permit custom error messages?
-
     // TODO Consider a different error type such that in-memory connections can be rejected as
     // necessary.
     /// Create a new instance of the backend at the given location.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -27,7 +27,9 @@ mod sealed {
     impl<T> Sealed for Arc<T> {}
 }
 
-mod error;
+pub mod error;
+
+use error::BackendError;
 
 // #[cfg(feature = "duckdb")]
 // pub use self::duckdb::DuckDb;
@@ -43,12 +45,12 @@ pub trait DatabaseBackend: sealed::Sealed + Sized {
     /// The type of connection to the database.
     type Connection;
     /// The type of any errors returned by the backend.
-    type Error; // TODO permit custom error messages?
+    // type Error; // TODO permit custom error messages?
 
     // TODO Consider a different error type such that in-memory connections can be rejected as
     // necessary.
     /// Create a new instance of the backend at the given location.
-    fn at_location(location: Location) -> Result<Self, Self::Error>;
+    fn at_location(location: Location) -> Result<Self, BackendError>;
 
     /// The location of the database.
     fn location(&self) -> &Location;
@@ -56,7 +58,7 @@ pub trait DatabaseBackend: sealed::Sealed + Sized {
     /// Note: Backends for specific stores provide their own versions of `connect` that initialize
     /// the store as necessary. It is recommended to **not** call this method directly unless you
     /// are implementing a new backend.
-    fn connect(&self) -> Result<Self::Connection, Self::Error>;
+    fn connect(&self) -> Result<Self::Connection, BackendError>;
 }
 
 /// A backend that supports key-value operations.
@@ -73,12 +75,12 @@ pub trait KvBackend: DatabaseBackend + Send + Sync {
     fn initialize(
         &self,
         #[allow(unused_variables)] connection: &Self::Connection,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), BackendError> {
         Ok(())
     }
 
     /// Connect to the key-value store, initializing it if necessary.
-    fn connect_kv(&self) -> Result<Self::Connection, Self::Error> {
+    fn connect_kv(&self) -> Result<Self::Connection, BackendError> {
         let conn = self.connect()?;
         self.initialize(&conn)?;
         Ok(conn)
@@ -119,12 +121,12 @@ pub trait BlobBackend: DatabaseBackend + Send + Sync {
     fn initialize(
         &self,
         #[allow(unused_variables)] connection: &Self::Connection,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), BackendError> {
         Ok(())
     }
 
     /// Connect to the BLOB store, initializing it if necessary.
-    fn connect_blob(&self) -> Result<Self::Connection, Self::Error> {
+    fn connect_blob(&self) -> Result<Self::Connection, BackendError> {
         let conn = self.connect()?;
         self.initialize(&conn)?;
         Ok(conn)

--- a/src/backend/sqlite.rs
+++ b/src/backend/sqlite.rs
@@ -1,3 +1,4 @@
+use crate::backend::error::BackendError;
 use crate::backend::{helpers, BlobBackend, DatabaseBackend, KvBackend};
 use crate::conv::try_into_protobuf_any;
 use crate::interop::into_tonic_status;
@@ -19,9 +20,9 @@ pub struct Sqlite {
 
 impl DatabaseBackend for Sqlite {
     type Connection = Connection;
-    type Error = rusqlite::Error;
+    // type Error = rusqlite::Error;
 
-    fn at_location(location: Location) -> Result<Self, Self::Error> {
+    fn at_location(location: Location) -> Result<Self, BackendError> {
         Ok(Self {
             location,
             initialized: AtomicBool::new(false),
@@ -32,10 +33,10 @@ impl DatabaseBackend for Sqlite {
         &self.location
     }
 
-    fn connect(&self) -> Result<Self::Connection, Self::Error> {
+    fn connect(&self) -> Result<Self::Connection, BackendError> {
         match &self.location() {
-            Location::InMemory => Connection::open_in_memory(),
-            Location::OnDisk { path } => Connection::open(path),
+            Location::InMemory => Ok(Connection::open_in_memory()?),
+            Location::OnDisk { path } => Ok(Connection::open(path)?),
         }
     }
 }
@@ -122,7 +123,7 @@ impl KvBackend for Sqlite {
     type DeleteStream = DynStream<Result<kv::DeleteResponse, Status>>;
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    fn initialize(&self, connection: &Self::Connection) -> Result<(), Self::Error> {
+    fn initialize(&self, connection: &Self::Connection) -> Result<(), BackendError> {
         let _res = connection.execute(
             "CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT)",
             [],
@@ -132,7 +133,7 @@ impl KvBackend for Sqlite {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    fn connect_kv(&self) -> Result<Self::Connection, Self::Error> {
+    fn connect_kv(&self) -> Result<Self::Connection, BackendError> {
         let conn = self.connect()?;
         if !self.initialized.load(Ordering::Relaxed) {
             KvBackend::initialize(self, &conn)?;
@@ -252,7 +253,7 @@ impl BlobBackend for Sqlite {
     type DeleteStream = DynStream<Result<blob::DeleteResponse, Status>>;
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    fn initialize(&self, connection: &Self::Connection) -> Result<(), Self::Error> {
+    fn initialize(&self, connection: &Self::Connection) -> Result<(), BackendError> {
         connection.execute_batch(
             "CREATE TABLE IF NOT EXISTS blob(
                 data BLOB,
@@ -264,7 +265,7 @@ impl BlobBackend for Sqlite {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    fn connect_blob(&self) -> Result<Self::Connection, Self::Error> {
+    fn connect_blob(&self) -> Result<Self::Connection, BackendError> {
         let conn = self.connect()?;
         if !self.initialized.load(Ordering::Relaxed) {
             BlobBackend::initialize(self, &conn)?;

--- a/src/backend/sqlite_transaction.rs
+++ b/src/backend/sqlite_transaction.rs
@@ -1,6 +1,8 @@
 use crate::backend::sqlite::Sqlite;
 use crate::backend::KvBackend;
-use crate::transaction::{Transaction, TransactionalBackend, TransactionalKvBackend};
+use crate::transaction::{
+    Transaction, TransactionError, TransactionalBackend, TransactionalKvBackend,
+};
 use crate::RpcResponse;
 use rusqlite::Connection;
 use std::sync::{Arc, Mutex};
@@ -26,9 +28,9 @@ impl SqliteTransaction {
 }
 
 impl Transaction for SqliteTransaction {
-    type Error = rusqlite::Error;
+    // type Error = rusqlite::Error;
 
-    fn commit(self) -> Result<(), Self::Error> {
+    fn commit(self) -> Result<(), TransactionError> {
         let mut committed = self.committed.lock().map_err(|_| {
             rusqlite::Error::SqliteFailure(
                 rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_MISUSE),
@@ -52,7 +54,7 @@ impl Transaction for SqliteTransaction {
         Ok(())
     }
 
-    fn rollback(self) -> Result<(), Self::Error> {
+    fn rollback(self) -> Result<(), TransactionError> {
         let mut committed = self.committed.lock().map_err(|_| {
             rusqlite::Error::SqliteFailure(
                 rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_MISUSE),
@@ -93,13 +95,13 @@ impl Drop for SqliteTransaction {
 impl TransactionalBackend for Sqlite {
     type Transaction = SqliteTransaction;
 
-    fn begin_transaction(&self) -> Result<Self::Transaction, Self::Error> {
+    fn begin_transaction(&self) -> Result<Self::Transaction, TransactionError> {
         let conn = self.connect_kv()?;
         let _ = conn.execute("BEGIN IMMEDIATE", [])?;
         Ok(SqliteTransaction::new(conn))
     }
 
-    fn begin_read_transaction(&self) -> Result<Self::Transaction, Self::Error> {
+    fn begin_read_transaction(&self) -> Result<Self::Transaction, TransactionError> {
         let conn = self.connect_kv()?;
         let _ = conn.execute("BEGIN", [])?;
         Ok(SqliteTransaction::new(conn))

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,7 +1,7 @@
 //! A store for binary large objects (BLOBs) with an optional metadata field.
 
+use crate::backend::error::BackendError;
 use crate::backend::{BlobBackend, DatabaseBackend};
-use crate::interop::IntoTonicStatus;
 use crate::proto::blob::{
     DeleteRequest, EqDataRequest, GetRequest, NotEqDataRequest, StoreRequest, UpdateRequest,
 };
@@ -27,7 +27,7 @@ where
     /// Create a new key-value store at the given location. If not pre-existing, the store will not
     /// be initialized until the first connection is made.
     #[inline]
-    pub fn at_location(location: Location) -> Result<Self, Backend::Error> {
+    pub fn at_location(location: Location) -> Result<Self, BackendError> {
         Ok(Self {
             backend: Backend::at_location(location)?,
         })
@@ -36,7 +36,7 @@ where
     /// Create a new key-value at the given path on disk. If not pre-existing, the store will not be
     /// initialized until the first connection is made.
     #[inline]
-    pub fn at_path<P>(path: P) -> Result<Self, Backend::Error>
+    pub fn at_path<P>(path: P) -> Result<Self, BackendError>
     where
         P: Into<PathBuf>,
     {
@@ -48,7 +48,7 @@ where
     /// Note that all in-memory connections share the same stream, so any asynchronous calls have a
     /// nondeterministic order. This is not a problem for on-disk connections.
     #[inline]
-    pub fn in_memory() -> Result<Self, Backend::Error> {
+    pub fn in_memory() -> Result<Self, BackendError> {
         Self::at_location(Location::InMemory)
     }
 }
@@ -56,13 +56,8 @@ where
 #[tonic::async_trait]
 impl<Backend> BlobRpc for BlobStore<Backend>
 where
-    Backend: BlobBackend<
-            Error: IntoTonicStatus,
-            GetStream: Send,
-            StoreStream: Send,
-            UpdateStream: Send,
-            DeleteStream: Send,
-        > + 'static,
+    Backend: BlobBackend<GetStream: Send, StoreStream: Send, UpdateStream: Send, DeleteStream: Send>
+        + 'static,
 {
     type GetStream = Backend::GetStream;
     type StoreStream = Backend::StoreStream;

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,8 +1,8 @@
 //! A key-value store.
 
+use crate::backend::error::BackendError;
 use crate::backend::{DatabaseBackend, KvBackend};
 use crate::index::{IndexConfig, IndexManager};
-use crate::interop::IntoTonicStatus;
 use crate::proto::kv::{
     BeginTransactionRequest, BeginTransactionResponse, CommitTransactionRequest,
     CommitTransactionResponse, DeleteRequest, EqRequest, GetRequest, NotEqRequest,
@@ -34,12 +34,11 @@ pub struct KvStore<Backend: TransactionalBackend> {
 impl<Backend> KvStore<Backend>
 where
     Backend: DatabaseBackend + TransactionalBackend,
-    Backend::Error: std::fmt::Display + std::fmt::Debug,
 {
     /// Create a new key-value store at the given location. If not pre-existing, the store will not
     /// be initialized until the first connection is made.
     #[inline]
-    pub fn at_location(location: Location) -> Result<Self, Backend::Error> {
+    pub fn at_location(location: Location) -> Result<Self, BackendError> {
         Ok(Self {
             backend: Backend::at_location(location)?,
             transaction_manager: None,
@@ -50,7 +49,7 @@ where
     /// Create a new key-value at the given path on disk. If not pre-existing, the store will not be
     /// initialized until the first connection is made.
     #[inline]
-    pub fn at_path<P>(path: P) -> Result<Self, Backend::Error>
+    pub fn at_path<P>(path: P) -> Result<Self, BackendError>
     where
         P: Into<PathBuf>,
     {
@@ -62,7 +61,7 @@ where
     /// Note that all in-memory connections share the same stream, so any asynchronous calls have a
     /// nondeterministic order. This is not a problem for on-disk connections.
     #[inline]
-    pub fn in_memory() -> Result<Self, Backend::Error> {
+    pub fn in_memory() -> Result<Self, BackendError> {
         Self::at_location(Location::InMemory)
     }
 
@@ -85,7 +84,6 @@ where
 impl<Backend> KvStore<Backend>
 where
     Backend: TransactionalBackend,
-    Backend::Error: std::fmt::Display,
 {
     /// Create a new key-value store with transaction support.
     ///
@@ -98,7 +96,7 @@ where
     pub fn with_transactions(
         location: Location,
         transaction_timeout: Duration,
-    ) -> Result<Self, Backend::Error> {
+    ) -> Result<Self, BackendError> {
         Ok(Self {
             backend: Backend::at_location(location)?,
             transaction_manager: Some(Arc::new(TransactionManager::new(transaction_timeout))),
@@ -110,10 +108,9 @@ where
 #[tonic::async_trait]
 impl<Backend> KvRpc for KvStore<Backend>
 where
-    Backend: KvBackend<Error: IntoTonicStatus, GetStream: Send, SetStream: Send, DeleteStream: Send>
+    Backend: KvBackend<GetStream: Send, SetStream: Send, DeleteStream: Send>
         + TransactionalBackend
         + 'static,
-    Backend::Error: std::fmt::Display + std::fmt::Debug,
 {
     type GetStream = Backend::GetStream;
     type SetStream = Backend::SetStream;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod tracing_shim;
 
 use crate::cli::{Args, Backend, BlobArgs, BlobUpdateMode, Command, KvArgs, RunArgs};
 use crate::tracing_shim::debug;
+use buffdb::backend::error::BackendError;
 #[cfg(feature = "duckdb")]
 use buffdb::backend::DuckDb;
 #[cfg(feature = "sqlite")]
@@ -30,6 +31,7 @@ use tokio::io::{self, AsyncReadExt as _, AsyncWriteExt as _};
 use tonic::transport::Server;
 
 /// A custom error message.
+
 #[derive(Debug)]
 struct ErrStr(&'static str);
 
@@ -90,17 +92,16 @@ async fn run<Backend>(
     }: RunArgs,
 ) -> Result<ExitCode, Box<dyn std::error::Error>>
 where
-    Backend: DatabaseBackend<Error: IntoTonicStatus + std::error::Error>
+    Backend: DatabaseBackend
         + KvBackend<GetStream: Send, SetStream: Send, DeleteStream: Send>
         + BlobBackend<GetStream: Send, StoreStream: Send, UpdateStream: Send, DeleteStream: Send>
         + buffdb::transaction::TransactionalBackend
         + 'static,
-    Backend::Error: std::fmt::Display + std::fmt::Debug,
 {
     if kv_store == blob_store {
-        return Err(Box::new(ErrStr(
-            "kv_store and blob_store cannot be at the same location",
-        )));
+        return Err(Box::new(BackendError::InvalidLocation {
+            message: "kv_store and blob_store cannot be at the same location".into(),
+        }));
     } else {
         // Rust's standard library has extension traits for Unix and Windows. Windows doesn't have
         // the concept of hard links, so there's no need to check an equivalent of inodes.
@@ -114,9 +115,9 @@ where
                 kv_store_metadata.ok().zip(blob_store_metadata.ok())
             {
                 if kv_store_metadata.ino() == blob_store_metadata.ino() {
-                    return Err(Box::new(ErrStr(
-                        "kv_store and blob_store cannot be at the same location",
-                    )));
+                    return Err(Box::new(BackendError::InvalidLocation {
+                        message: "kv_store and blob_store cannot be at the same location".into(),
+                    }));
                 }
             }
         }
@@ -152,10 +153,9 @@ async fn kv<Backend>(
     KvArgs { store, command }: KvArgs,
 ) -> Result<ExitCode, Box<dyn std::error::Error>>
 where
-    Backend: KvBackend<GetStream: Send, SetStream: Send, DeleteStream: Send, Error: IntoTonicStatus>
+    Backend: KvBackend<GetStream: Send, SetStream: Send, DeleteStream: Send>
         + buffdb::transaction::TransactionalBackend
         + 'static,
-    Backend::Error: std::fmt::Display + std::fmt::Debug,
 {
     let mut client = transitive::kv_client::<_, Backend>(store).await?;
     match command {
@@ -170,7 +170,10 @@ where
 
             let mut stdout = io::stdout();
             let Some(kv::GetResponse { value }) = values.message().await? else {
-                return Err(Box::new(ErrStr("expected at least one value")));
+                // return Err(Box::new(ErrStr("expected at least one value")));
+                return Err(Box::new(BackendError::Generic {
+                    message: "expected at least one value".into(),
+                }));
             };
             stdout.write_all(value.as_bytes()).await?;
             while let Some(kv::GetResponse { value }) = values.message().await? {
@@ -237,15 +240,9 @@ async fn blob<Backend>(
     BlobArgs { store, command }: BlobArgs,
 ) -> Result<ExitCode, Box<dyn std::error::Error>>
 where
-    Backend: BlobBackend<
-            GetStream: Send,
-            StoreStream: Send,
-            UpdateStream: Send,
-            DeleteStream: Send,
-            Error: IntoTonicStatus,
-        > + buffdb::transaction::TransactionalBackend
+    Backend: BlobBackend<GetStream: Send, StoreStream: Send, UpdateStream: Send, DeleteStream: Send>
+        + buffdb::transaction::TransactionalBackend
         + 'static,
-    Backend::Error: std::fmt::Display + std::fmt::Debug,
 {
     let mut client = transitive::blob_client::<_, Backend>(store.clone()).await?;
     match command {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,6 @@
+use crate::backend::error::BackendError;
 use crate::backend::DatabaseBackend;
-use crate::interop::{into_tonic_status, IntoTonicStatus};
+use crate::interop::into_tonic_status;
 use crate::proto::query::{QueryResult, RawQuery, RowsChanged, TargetStore};
 use crate::queryable::Queryable;
 use crate::service::query::QueryRpc;
@@ -27,7 +28,7 @@ where
     pub fn at_location(
         kv_location: Location,
         blob_location: Location,
-    ) -> Result<Self, Backend::Error> {
+    ) -> Result<Self, BackendError> {
         // TODO validate that both locations are not in memory
         Ok(Self {
             kv_backend: Backend::at_location(kv_location)?,
@@ -37,7 +38,7 @@ where
 
     /// Create a new query handler at the given paths on disk. No initialization is performed.
     #[inline]
-    pub fn at_path<P1, P2>(kv_path: P1, blob_path: P2) -> Result<Self, Backend::Error>
+    pub fn at_path<P1, P2>(kv_path: P1, blob_path: P2) -> Result<Self, BackendError>
     where
         P1: Into<std::path::PathBuf>,
         P2: Into<std::path::PathBuf>,
@@ -52,7 +53,7 @@ where
 #[tonic::async_trait]
 impl<Backend> QueryRpc for QueryHandler<Backend>
 where
-    Backend: DatabaseBackend<Error: IntoTonicStatus, Connection: Send>
+    Backend: DatabaseBackend<Connection: Send>
         + Queryable<Connection = <Backend as DatabaseBackend>::Connection, QueryStream: Send>
         + Send
         + Sync

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,28 +1,47 @@
+use crate::backend::error::BackendError;
+use crate::interop::IntoTonicStatus;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use thiserror::Error;
 use uuid::Uuid;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct TransactionError(#[from] BackendError);
+
+impl IntoTonicStatus for TransactionError {
+    fn into_tonic_status(self) -> tonic::Status {
+        self.0.into_tonic_status()
+    }
+}
+
+impl From<rusqlite::Error> for TransactionError {
+    fn from(value: rusqlite::Error) -> Self {
+        TransactionError(value.into())
+    }
+}
 
 /// Represents an active database transaction
 pub trait Transaction: Send + Sync {
-    type Error: std::error::Error + std::fmt::Display + Send + Sync + 'static;
+    // type Error: std::error::Error + std::fmt::Display + Send + Sync + 'static;
 
     /// Commit the transaction, making all changes permanent
-    fn commit(self) -> Result<(), Self::Error>;
+    fn commit(self) -> Result<(), TransactionError>;
 
     /// Rollback the transaction, discarding all changes
-    fn rollback(self) -> Result<(), Self::Error>;
+    fn rollback(self) -> Result<(), TransactionError>;
 }
 
 /// Extended trait for database backends that support transactions
 pub trait TransactionalBackend: crate::backend::DatabaseBackend {
-    type Transaction: Transaction<Error = Self::Error> + std::fmt::Debug;
+    type Transaction: Transaction + std::fmt::Debug;
 
     /// Begin a new transaction
-    fn begin_transaction(&self) -> Result<Self::Transaction, Self::Error>;
+    fn begin_transaction(&self) -> Result<Self::Transaction, TransactionError>;
 
     /// Begin a new read-only transaction
-    fn begin_read_transaction(&self) -> Result<Self::Transaction, Self::Error> {
+    fn begin_read_transaction(&self) -> Result<Self::Transaction, TransactionError> {
         // Default implementation just creates a regular transaction
         // Backends can override for optimization
         self.begin_transaction()
@@ -37,10 +56,7 @@ pub struct TransactionManager<Backend: TransactionalBackend> {
     default_timeout: Duration,
 }
 
-impl<Backend: TransactionalBackend> TransactionManager<Backend>
-where
-    Backend::Error: std::fmt::Display,
-{
+impl<Backend: TransactionalBackend> TransactionManager<Backend> {
     /// Create a new transaction manager
     pub fn new(default_timeout: Duration) -> Self {
         Self {
@@ -55,7 +71,7 @@ where
         backend: &Backend,
         read_only: bool,
         timeout_ms: Option<i32>,
-    ) -> Result<String, Backend::Error> {
+    ) -> Result<String, TransactionError> {
         let transaction = if read_only {
             backend.begin_read_transaction()?
         } else {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -18,7 +18,7 @@ impl IntoTonicStatus for TransactionError {
 
 impl From<rusqlite::Error> for TransactionError {
     fn from(value: rusqlite::Error) -> Self {
-        TransactionError(value.into())
+        Self(value.into())
     }
 }
 

--- a/src/transitive.rs
+++ b/src/transitive.rs
@@ -4,7 +4,7 @@ use crate::backend::{BlobBackend, DatabaseBackend, KvBackend};
 use crate::client::blob::BlobClient;
 use crate::client::kv::KvClient;
 use crate::client::query::QueryClient;
-use crate::interop::{into_tonic_status, IntoTonicStatus};
+use crate::interop::into_tonic_status;
 use crate::query::QueryHandler;
 use crate::queryable::Queryable;
 use crate::server::blob::BlobServer;
@@ -17,20 +17,23 @@ use crate::Location;
 use hyper_util::rt::TokioIo;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
+use thiserror::Error;
 use tonic::transport::{Channel, Endpoint, Server};
 use tonic::Status;
 
 const DUPLEX_SIZE: usize = 1024;
 
 /// An error from a transitive client.
-#[derive(Debug)]
+#[derive(Error, Debug)]
+#[error("Transitive error")]
 pub enum TransitiveError {
     /// An error from the server.
-    Status(Status),
+    Status(#[from] Status),
     /// An error from the transport layer.
-    Transport(tonic::transport::Error),
+    Transport(#[from] tonic::transport::Error),
 }
 
+/*
 impl fmt::Display for TransitiveError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -60,6 +63,7 @@ impl From<tonic::transport::Error> for TransitiveError {
         Self::Transport(error)
     }
 }
+*/
 
 // TODO Add a way to shut down the server, both manually and automatically on drop.
 /// A temporary client for a data store.
@@ -102,11 +106,10 @@ macro_rules! declare_clients {
         ) -> Result<Transitive<$client<Channel>>, TransitiveError>
         where
             L: Into<Location> + Send + fmt::Debug,
-            Backend: DatabaseBackend<Error: IntoTonicStatus>
+            Backend: DatabaseBackend
                 + $backend<$($bounds)*>
                 + transaction::TransactionalBackend
                 + 'static,
-            Backend::Error: std::fmt::Display + std::fmt::Debug
         {
             let location = location.into();
             let (client, server) = tokio::io::duplex(DUPLEX_SIZE);
@@ -179,7 +182,7 @@ pub async fn query_client<L1, L2, Backend>(
 where
     L1: Into<Location> + Send + fmt::Debug,
     L2: Into<Location> + Send + fmt::Debug,
-    Backend: DatabaseBackend<Error: IntoTonicStatus, Connection: Send>
+    Backend: DatabaseBackend<Connection: Send>
         + Queryable<Connection = <Backend as DatabaseBackend>::Connection, QueryStream: Send>
         + Send
         + Sync


### PR DESCRIPTION
- [x] investigate all the possible errors
- [x] define properly in the `src/backend/error.rs`
- [ ] replace calls `unwrap`, `expect` calls with the proper equivalent errors.